### PR TITLE
[fix] forbid enabling metrics without a cron schedule

### DIFF
--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -14,7 +14,7 @@ type Prometheus struct {
 	lastBackupTimestamp prometheus.Gauge
 	lastBackupSize      prometheus.Gauge
 	backupDuration      prometheus.Histogram
-	backupStatus        prometheus.GaugeVec
+	backupStatus        prometheus.Gauge
 }
 
 var defaultPrometheus atomic.Value
@@ -57,12 +57,12 @@ func NewPrometheusMetrics(namespace, subsys string) (*Prometheus, *prometheus.Re
 		Subsystem: subsys,
 	})
 
-	prom.backupStatus = *prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	prom.backupStatus = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name:      "backup_last_status",
 		Help:      "The status of the last backup (1=success, 0=failure).",
 		Namespace: namespace,
 		Subsystem: subsys,
-	}, []string{"status"})
+	})
 
 	errs = append(errs,
 		promReg.Register(collectors.NewBuildInfoCollector()),
@@ -98,6 +98,5 @@ func SetBackupStatus(success bool) {
 	if success {
 		status = 1.0
 	}
-	DefaultMetrics().backupStatus.WithLabelValues("success").Set(status)
-	DefaultMetrics().backupStatus.WithLabelValues("failure").Set(1.0 - status)
+	DefaultMetrics().backupStatus.Set(status)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,6 +32,10 @@ func Execute() {
 		log.Panic().Err(err).Msg("Failed to init config")
 	}
 
+	if cfg.Metrics.Enable && cfg.Schedule.Cron == "" {
+		log.Panic().Msg("Metrics cannot be enabled without a cron schedule")
+	}
+
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
@@ -40,7 +44,7 @@ func Execute() {
 		WithFirstError().
 		WithCancelOnError()
 
-	if cfg.Metrics.Enable && cfg.Schedule.Cron != "" {
+	if cfg.Metrics.Enable {
 		mux := http.NewServeMux()
 
 		promMetrics, promReg, err := NewPrometheusMetrics(cfg.Metrics.Namespace, cfg.Metrics.Subsystem)


### PR DESCRIPTION
This PR makes two improvements to the backup metrics system:
* Simplify backupStatus metric
* Changed backupStatus to a single Gauge (no labels anymore)
  * 1 indicates a successful backup, 0 indicates failure.
* Enforce metrics only with a cron schedule
